### PR TITLE
fix typo in FramePositionMotionConverter

### DIFF
--- a/finnr/motion/position_converter.py
+++ b/finnr/motion/position_converter.py
@@ -1,6 +1,6 @@
 class FramePositionMotionConverter(object):
     def __init__(self, frame_width, frame_height):
-        self.frame_width = frame_height
+        self.frame_width = frame_width
         self.frame_height = frame_height
 
     def convert(self, position):


### PR DESCRIPTION
Constructor of FramePositionMotionConverter is not correct.
FramePositionMotionConverter(frame_width, frame_height) returns an object with fields self.frame_width = frame_height and  self.frame_height = frame_height.

In this [paper](http://docdro.id/1zmtBTa) I proof the correctness of my solution using knot theory.

